### PR TITLE
Ajout d'une vérification de connectivité à l'AD avant de rejoindre celui-ci

### DIFF
--- a/Set-PC01.ps1
+++ b/Set-PC01.ps1
@@ -94,11 +94,15 @@ function Invoke-PC01Setup {
         $password = "R00tR00t" | ConvertTo-SecureString -asPlainText -Force
         $username = "$domain\Administrateur" 
         $credential = New-Object System.Management.Automation.PSCredential($username,$password)
-        Add-Computer -DomainName $domain -Credential $credential  | Out-Null 
-
-        Sleep 5
-        restart-computer
-
+        #Verif ping du domaine avant lancement de la connection
+        if (Test-Connection -ComputerName "WOODENSEC" -Count 5 -Quiet) { 
+            Add-Computer -DomainName $domain -Credential $credential  | Out-Null
+            Start-Sleep 5
+            restart-computer
+        } else {
+            Write-Error "Erreur Impossible de Ping l'AD Vérfier la connectivité ou le DNS... Arrêt dans 5sec !"
+            Start-Sleep 5
+        }
     }
     else { write-host("Il semblerait que le PC soit entièrement configuré") }
 } 

--- a/Set-PC01.ps1
+++ b/Set-PC01.ps1
@@ -95,7 +95,7 @@ function Invoke-PC01Setup {
         $username = "$domain\Administrateur" 
         $credential = New-Object System.Management.Automation.PSCredential($username,$password)
         #Verif ping du domaine avant lancement de la connection
-        if (Test-Connection -ComputerName "WOODENSEC" -Count 5 -Quiet) { 
+        if (Test-Connection -ComputerName "WODENSEC" -Count 5 -Quiet) { 
             Add-Computer -DomainName $domain -Credential $credential  | Out-Null
             Start-Sleep 5
             restart-computer

--- a/Set-PC01.ps1
+++ b/Set-PC01.ps1
@@ -95,7 +95,7 @@ function Invoke-PC01Setup {
         $username = "$domain\Administrateur" 
         $credential = New-Object System.Management.Automation.PSCredential($username,$password)
         #Verif ping du domaine avant lancement de la connection
-        if (Test-Connection -ComputerName "WODENSEC" -Count 5 -Quiet) { 
+        if (Test-Connection -ComputerName "WODENSEC.local" -Count 5 -Quiet) { 
             Add-Computer -DomainName $domain -Credential $credential  | Out-Null
             Start-Sleep 5
             restart-computer

--- a/Set-PC02.ps1
+++ b/Set-PC02.ps1
@@ -30,7 +30,7 @@ function Invoke-PC02Setup {
         $username = "$domain\Administrateur" 
         $credential = New-Object System.Management.Automation.PSCredential($username,$password)
         #Verif ping du domaine avant lancement de la connection
-        if (Test-Connection -ComputerName "WOODENSEC" -Count 5 -Quiet) { 
+        if (Test-Connection -ComputerName "WODENSEC" -Count 5 -Quiet) { 
             Add-Computer -DomainName $domain -Credential $credential  | Out-Null
             Start-Sleep 5
             restart-computer

--- a/Set-PC02.ps1
+++ b/Set-PC02.ps1
@@ -30,7 +30,7 @@ function Invoke-PC02Setup {
         $username = "$domain\Administrateur" 
         $credential = New-Object System.Management.Automation.PSCredential($username,$password)
         #Verif ping du domaine avant lancement de la connection
-        if (Test-Connection -ComputerName "WODENSEC" -Count 5 -Quiet) { 
+        if (Test-Connection -ComputerName "WODENSEC.local" -Count 5 -Quiet) { 
             Add-Computer -DomainName $domain -Credential $credential  | Out-Null
             Start-Sleep 5
             restart-computer

--- a/Set-PC02.ps1
+++ b/Set-PC02.ps1
@@ -29,11 +29,15 @@ function Invoke-PC02Setup {
         $password = "R00tR00t" | ConvertTo-SecureString -asPlainText -Force
         $username = "$domain\Administrateur" 
         $credential = New-Object System.Management.Automation.PSCredential($username,$password)
-        Add-Computer -DomainName $domain -Credential $credential  | Out-Null 
-
-        Sleep 5
-        restart-computer
-
+        #Verif ping du domaine avant lancement de la connection
+        if (Test-Connection -ComputerName "WOODENSEC" -Count 5 -Quiet) { 
+            Add-Computer -DomainName $domain -Credential $credential  | Out-Null
+            Start-Sleep 5
+            restart-computer
+        } else {
+            Write-Error "Erreur Impossible de Ping l'AD Vérfier la connectivité ou le DNS... Arrêt dans 5sec !"
+            Start-Sleep 5
+        }
     }
     else { write-host("Il semblerait que le PC soit entièrement configuré") }
 } 


### PR DESCRIPTION
Changement de Sleep en Start-Sleep pour limiter les alias
Ajout de la vérification de connectivité dans le cas de soucis de dns ou de connectivité afin d'éviter un redémarrage inutile si le pc n'a pas réussi à rejoindre l'AD